### PR TITLE
[Feat] 프로토타입 패턴 적용 후 clone() shallow copy -> deep copy

### DIFF
--- a/src/main/java/com/ji/creational_patterns/prototype/after/App.java
+++ b/src/main/java/com/ji/creational_patterns/prototype/after/App.java
@@ -2,7 +2,32 @@ package com.ji.creational_patterns.prototype.after;
 
 public class App {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws CloneNotSupportedException {
+
+        GithubRepository repository = new GithubRepository();
+        repository.setUser("whiteship");
+        repository.setName("live-study");
+
+        GithubIssue githubIssue = new GithubIssue(repository);
+        githubIssue.setId(1);
+        githubIssue.setTitle("1주차 과제: JVM은 무엇이며 자바 코드는 어떻게 실행하는 것인가.");
+
+        String url = githubIssue.getUrl();
+        System.out.println(url);
+
+        GithubIssue clone = (GithubIssue) githubIssue.clone();
+        System.out.println(clone.getUrl());
+
+        repository.setUser("Seonhak");
+
+        //Java는 기본적으로 shallow copy이지만 clone()을 오버라이딩하여 deep copy를 구현할 수 있음
+        System.out.println(clone != githubIssue);
+        System.out.println(clone.equals(githubIssue));
+        System.out.println(clone.getClass() == githubIssue.getClass());
+        System.out.println(clone.getRepository() == githubIssue.getRepository());
+
+        System.out.println(clone.getUrl());
+
 
     }
 }

--- a/src/main/java/com/ji/creational_patterns/prototype/after/GithubIssue.java
+++ b/src/main/java/com/ji/creational_patterns/prototype/after/GithubIssue.java
@@ -1,0 +1,70 @@
+package com.ji.creational_patterns.prototype.after;
+
+import java.util.Objects;
+
+public class GithubIssue implements Cloneable {
+    private int id;
+
+    private String title;
+
+    private GithubRepository repository;
+
+    public GithubIssue(GithubRepository repository) {
+        this.repository = repository;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public GithubRepository getRepository() {
+        return repository;
+    }
+
+    public String getUrl() {
+        return String.format("https://github.com/%s/%s/issues/%d",
+                repository.getUser(),
+                repository.getName(),
+                this.getId());
+    }
+
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        GithubRepository repository = new GithubRepository();
+        repository.setUser(this.repository.getUser());
+        repository.setName(this.repository.getName());
+
+        //Deep Copy
+        GithubIssue githubIssue = new GithubIssue(repository);
+        githubIssue.setId(this.id);
+        githubIssue.setTitle(this.title);
+
+        return githubIssue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GithubIssue that = (GithubIssue) o;
+        return id == that.id && Objects.equals(title, that.title) && Objects.equals(repository, that.repository);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title, repository);
+    }
+
+}

--- a/src/main/java/com/ji/creational_patterns/prototype/after/GithubRepository.java
+++ b/src/main/java/com/ji/creational_patterns/prototype/after/GithubRepository.java
@@ -1,0 +1,24 @@
+package com.ji.creational_patterns.prototype.after;
+
+public class GithubRepository {
+    private String user;
+
+    private String name;
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}


### PR DESCRIPTION
Java에서 제공하는 clone()은 기본적으로 shallow copy를 지원하지만 
deep copy 형태를 구현하고 싶으면 복사할 데이터를 가지고와서 새로운 객체에 넣어줍니다.
```
  @Override
    protected Object clone() throws CloneNotSupportedException {
        GithubRepository repository = new GithubRepository();
        repository.setUser(this.repository.getUser());
        repository.setName(this.repository.getName());

        //Deep Copy
        GithubIssue githubIssue = new GithubIssue(repository);
        githubIssue.setId(this.id);
        githubIssue.setTitle(this.title);

        return githubIssue;
    }
    